### PR TITLE
Fix compile error:

### DIFF
--- a/QFtpServer/mainwindow.cpp
+++ b/QFtpServer/mainwindow.cpp
@@ -6,6 +6,7 @@
 #include <QCoreApplication>
 #include <QSettings>
 #include <QFileDialog>
+#include <QIntValidator>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow)


### PR DESCRIPTION
../../../QFtpServerCommandLine/main.cpp: In function ‘QChar getRandomChar()’:
../../../QFtpServerCommandLine/main.cpp:9:30: warning: ‘int qrand()’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
    9 |     return QChar('a' + (qrand()%('z'-'a')));
      |                         ~~~~~^~
In file included from /opt/Qt/5.15.2/gcc_64/include/QtCore/qcoreapplication.h:43,
                 from /opt/Qt/5.15.2/gcc_64/include/QtCore/QCoreApplication:1,
                 from ../../../QFtpServerCommandLine/main.cpp:1:
/opt/Qt/5.15.2/gcc_64/include/QtCore/qglobal.h:1279:80: note: declared here
 1279 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") int qrand();
      |                                                                                ^~~~~
../../../QFtpServerCommandLine/main.cpp: In function ‘int main(int, char**)’:
../../../QFtpServerCommandLine/main.cpp:26:11: warning: ‘void qsrand(uint)’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
   26 |     qsrand(QTime::currentTime().msec());
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/Qt/5.15.2/gcc_64/include/QtCore/qglobal.h:1278:81: note: declared here
 1278 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") void qsrand(uint seed);
      |                                                                                 ^~~~~~
../../../QFtpServer/mainwindow.cpp: In constructor ‘MainWindow::MainWindow(QWidget*)’:
../../../QFtpServer/mainwindow.cpp:15:40: error: expected type-specifier before ‘QIntValidator’
   15 |     ui->lineEditPort->setValidator(new QIntValidator(1, 65535, this));
      |                                        ^~~~~~~~~~~~~
